### PR TITLE
Add files via upload

### DIFF
--- a/WebPTest/WebPTest.csproj
+++ b/WebPTest/WebPTest.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WebPTest</RootNamespace>
     <AssemblyName>WebPTest</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
@@ -119,7 +119,7 @@
     <Content Include="libwebp_x64.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-	<Content Include="libwebp_x86.dll">
+    <Content Include="libwebp_x86.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="WildCherry.png">

--- a/WebPTest/app.config
+++ b/WebPTest/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>


### PR DESCRIPTION
Updated to .NET Framework v4.6.2 
Store the delegate as an instance field to ensure it stays alive for the duration of the encoding process, preventing the GC from collecting it prematurely.